### PR TITLE
notes about 5-level paging and pci realloc

### DIFF
--- a/docs/datacenter_setup/memory.mdx
+++ b/docs/datacenter_setup/memory.mdx
@@ -91,15 +91,51 @@ Edit the `/etc/default/grub` file and modify the line containing `GRUB_CMDLINE_L
 Add `default_hugepagesz=1G hugepagesz=1G hugepages=<num>` to the `GRUB_CMDLINE_LINUX` options.
 The `<num>` is the number of huge pages to allocate. For example:
 ```
-GRUB_CMDLINE_LINUX="default_hugepagesz=1G hugepagesz=1G hugepages=2080"
+GRUB_CMDLINE_LINUX="... default_hugepagesz=1G hugepagesz=1G hugepages=2080"
 ```
 
-Update grub changes.
+Update grub changes and reboot (or do it after the next section).
 ```
 sudo update-grub
 ```
 
-### 4. Mount Huge Page Table
+### 4. (Optional) Enable 5-level Paging
+
+If you're planning to virtualize a large number of GPUs with a large amount of VRAM, like 8 x H100,
+you'll most likely need to enable 5-level paging. Otherwise, qemu won't be able to allocate
+large enough chunk of memory for passthrough. Check if your CPU supports 57-bit address space via:
+```
+$ lscpu | grep "Address sizes"
+```
+
+You should see an output like:
+```
+Address sizes:                        52 bits physical, 57 bits virtual
+```
+
+If so, add `la57` option to the `GRUB_CMDLINE_LINUX_DEFAULT` variable in `/etc/default/grub`:
+```
+GRUB_CMDLINE_LINUX_DEFAULT="la57"
+GRUB_CMDLINE_LINUX="... default_hugepagesz=1G hugepagesz=1G hugepages=2080"
+```
+
+For this option to work you also need to use a kernel with la57 support. To check if your kernel supports
+la57 option run `grep CONFIG_CMDLINE /boot/config-$(uname -r)`. You should see:
+```
+CONFIG_CMDLINE_BOOL=y
+CONFIG_CMDLINE="la57"
+```
+
+If CONFIG_CMDLINE_BOOL is not set or CONFIG_CMDLINE does not include la57, then your kernel won’t activate la57,
+even if it’s supported and passed in GRUB. You'll need to build a kernel with those options enabled.
+
+Update grub changes and reboot:
+```
+sudo update-grub
+sudo reboot
+```
+
+### 5. Mount Huge Page Table
 
 We need to mount the huge page table to the system, so that Hypervisor can use it.
 
@@ -119,7 +155,7 @@ hugetlbfs /dev/hugepages hugetlbfs rw,nosuid,nodev,relatime,pagesize=1024M 0 0
 hugetlbfs /mnt/hugepages-1G hugetlbfs rw,relatime,pagesize=1024M 0 0
 ```
 
-### 5. Persist the Mount on Reboot
+### 6. Persist the Mount on Reboot
 
 Add to `/etc/fstab`:
 
@@ -127,7 +163,7 @@ Add to `/etc/fstab`:
 none /mnt/hugepages-1G hugetlbfs pagesize=1G 0 0
 ```
 
-### 6. Reboot and Verify that the Configuration Works
+### 7. Reboot and Verify that the Configuration Works
 
 Reboot: `sudo reboot`
 

--- a/docs/datacenter_setup/vm.mdx
+++ b/docs/datacenter_setup/vm.mdx
@@ -87,7 +87,26 @@ sudo client_setup.sh --only=rift
 ```
 :::
 
-## 4. (Optional) Ensure that GPU is not Used by the System
+## 4. (Optional) Enable iommu=pt pci=realloc options
+
+The iommu=pt and pci=realloc kernel parameters in GRUB are used to optimize I/O operations and improve performance,
+particularly in virtualized environments or when dealing with GPUs with large amount of memory. The iommu=pt option
+enables IOMMU pass-through mode, bypassing DMA translation for better performance, while pci=realloc allows the kernel
+to reallocate PCI resources if the BIOS's initial allocation is insufficient.
+
+Add `iommu=pt pci=realloc` the following line in the `/etc/default/grub`.
+```
+GRUB_CMDLINE_LINUX_DEFAULT="... iommu=pt pci=realloc"
+```
+
+Then, invoke (or do it after the next section).
+```
+sudo update-grub
+sudo update-initramfs -u
+sudo reboot
+```
+
+## 5. (Optional) Ensure that GPU is not Used by the System
 
 Libvirt automatically binds the VFIO driver when VM is being allocated, but for greater stability it is
 best to ensure that VFIO driver is always bound and no driver changes are happening at runtime. Thus, first
@@ -96,7 +115,7 @@ blacklist all other drivers early and disable video mode setup to ensure that th
 Add `nomodeset video=efifb:off modprobe.blacklist=nouveau,nvidia,nvidiafb` the following line in the `/etc/default/grub`.
 Keep other options if needed.
 ```
-GRUB_CMDLINE_LINUX_DEFAULT="nomodeset modprobe.blacklist=nouveau,nvidia,nvidiafb video=efifb:off"
+GRUB_CMDLINE_LINUX_DEFAULT="... nomodeset modprobe.blacklist=nouveau,nvidia,nvidiafb video=efifb:off"
 ```
 
 Ensure that VFIO drivers are loaded:


### PR DESCRIPTION
Kazteleport asked to support virtualization of all 8 x H100. The problem was with the lack of 5-level pagging support. Unfortunately, I wasn't able to fix it since the kernel needs to be recompiled, but adding these notes for the future.